### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 [English](README.md) | [中文](README_CN.md) | [한국어](README_KO.md) | [日本語](README_JP.md) | [Français](README_FR.md) | [Deutsch](README_DE.md) | [Español](README_ES.md)
 
 <img width="3836" height="2026" alt="image" src="https://github.com/user-attachments/assets/d86c3d6b-6fd4-4cfe-b64f-67c465bb3d3c" /><img width="3832" height="2024" alt="image" src="https://github.com/user-attachments/assets/a91d2b13-07ac-4cae-ab33-506f1fa3bca6" />


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/everythingByMdfind/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=appledragon&project=everythingByMdfind&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
